### PR TITLE
Origin in the websocket connection 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # hubot-quip
 A Quip adapter for Hubot
+
+
+## Configuration settings
+To make this adapter work you should configure this variable in your system:
+
+`QUIP_HUBOT_TOKEN` Authentication token that you create when create the bot in the Quip admin console
+`QUIP_HUBOT_BASEURL` Optional parameter to choose your Quip server.

--- a/src/quip.coffee
+++ b/src/quip.coffee
@@ -90,7 +90,7 @@ class QuipHubot extends Adapter
     @robot.logger.info "Connecting..."
     return if @connected
     return @robot.logger.error "No Socket URL" unless @socketUrl
-    @ws = new WebSocket @socketUrl
+    @ws = new WebSocket @socketUrl, { origin: 'https://quip.com' }
     @ws.on "open", =>
       @robot.logger.info "Opened"
       @connected = true


### PR DESCRIPTION
The current version is not working. Quip API returns 403.

Its mandatory when starting the WSS connection send an origin, if this is not set the connection is not started.

Whit this PR this works again.
This PR also adds a very basic update in the README so people know what to configure.